### PR TITLE
Add EPT reader support to read_lidar function

### DIFF
--- a/pyforestscan/calculate.py
+++ b/pyforestscan/calculate.py
@@ -148,16 +148,20 @@ def calculate_pai(pad, min_height=1, max_height=None):
 
 def calculate_fhd(voxel_returns):
     """
-    Calculate the Frequency Histogram Diversity (FHD) for a given set of voxel returns.
+    Calculate the Foliage Height Diversity (FHD) for a given set of voxel returns.
 
-    This function computes the Frequency Histogram Diversity by calculating the entropy
-    of the voxel return proportions along the z-axis.
+    This function computes Foliage Height Diversity by calculating the entropy
+    of the voxel return proportions along the z-axis, which represents vertical structure
+    in the canopy.
 
     :param voxel_returns:
-        A numpy array of shape (x, y, z) representing voxel returns.
+        A numpy array of shape (x, y, z) representing voxel returns, where x and y are spatial
+        dimensions, and z represents height bins (or layers along the vertical axis).
 
     :return:
-        A numpy array of shape (x, y"""
+        A numpy array of shape (x, y) representing the FHD values for each (x, y) location.
+        Areas with no voxel returns will have NaN values.
+    """
     sum_counts = np.sum(voxel_returns, axis=2, keepdims=True)
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/pyforestscan/handlers.py
+++ b/pyforestscan/handlers.py
@@ -283,12 +283,14 @@ def write_las(arrays, output_file, srs=None, compress=True):
     if srs:
         pipeline_steps.append({
             "type": "filters.reprojection",
+            "in_srs": srs,
             "out_srs": srs
         })
 
     pipeline_steps.append({
         "type": output_format,
         "filename": output_file,
+        "minor_version": "4",
         "extra_dims": "all"
     })
 

--- a/pyforestscan/handlers.py
+++ b/pyforestscan/handlers.py
@@ -170,7 +170,7 @@ def read_lidar(input_file, srs, bounds=None, thin_radius=None, hag=False, hag_dt
     :param hag_dtm: bool, optional, If True, calculate Height Above Ground (HAG) using a DTM file.
     :param dtm: str, optional, The path to the DTM file used when hag_dtm is True. Must be a .tif file.
     :param crop_poly: bool, optional, If True, crop the point cloud using the polygon defined in the poly file.
-    :param poly: str, optional, The path to the polygon file used for cropping.
+    :param poly: str, optional, The path to the polygon file used for cropping OR the WKT of the Polygon geometry.
 
     :return: numpy.ndarray, The processed point cloud data or None if no data is retrieved.
 
@@ -207,8 +207,10 @@ def read_lidar(input_file, srs, bounds=None, thin_radius=None, hag=False, hag_dt
     if crop_poly:
         if not poly or not os.path.isfile(poly):
             raise FileNotFoundError(f"No such polygon file: '{poly}'")
-        polygon_wkt, crs_vector = load_polygon_from_file(poly)
-        crs_list.append(crs_vector)
+        if poly.strip().startswith(('POLYGON', 'MULTIPOLYGON')):
+            polygon_wkt = poly
+        else:
+            polygon_wkt, crs_vector = load_polygon_from_file(poly)
         pipeline_stages.append(_crop_polygon(polygon_wkt))
 
     if thin_radius is not None:

--- a/pyforestscan/handlers.py
+++ b/pyforestscan/handlers.py
@@ -205,11 +205,13 @@ def read_lidar(input_file, srs, bounds=None, thin_radius=None, hag=False, hag_dt
     crs_list = []
 
     if crop_poly:
-        if not poly or not os.path.isfile(poly):
-            raise FileNotFoundError(f"No such polygon file: '{poly}'")
+        if not poly:
+            raise ValueError(f"Must provide a polygon or polygon wkt if cropping to a polygon.")
         if poly.strip().startswith(('POLYGON', 'MULTIPOLYGON')):
             polygon_wkt = poly
         else:
+            if not poly or not os.path.isfile(poly):
+                raise FileNotFoundError(f"No such polygon file: '{poly}'")
             polygon_wkt, crs_vector = load_polygon_from_file(poly)
         pipeline_stages.append(_crop_polygon(polygon_wkt))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyforestscan",
-    version="0.1.6",
+    version="0.1.7",
     author="Joseph Emile Honour Percival",
     author_email="ipercival@gmail.com",
     description="Analyzing forest structure using aerial LiDAR data",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -221,7 +221,7 @@ def test_read_lidar_missing_dtm_file():
 def test_read_lidar_unsupported_input_extension():
     input_file = get_test_data_path("input.txt")
     srs = "EPSG:4326"
-    with pytest.raises(ValueError, match="The input file must be a .las, .laz, .copc, or .copc.laz file."):
+    with pytest.raises(ValueError, match="The input file must be a .las, .laz, .copc, .copc.laz file, or an ept.json file."):
         read_lidar(
             input_file=input_file,
             srs=srs


### PR DESCRIPTION
Extended the read_lidar function to support 'ept.json' file types by recognizing the EPT reader. Also included a new 'bounds' parameter for spatial cropping and streamlined the pipeline building process for better maintenance. Updated tests to match the new validation error message.

ref: https://github.com/iosefa/PyForestScan/issues/8