### PR TITLE
Enhance CHM interpolation logic and update tests.

### DIFF
--- a/.idea/PyForestScan.iml
+++ b/.idea/PyForestScan.iml
@@ -8,4 +8,11 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
 </module>


### PR DESCRIPTION
The interpolation parameter now supports a 'None' option, ensuring no interpolation is performed if desired. Adjusted the tests accordingly to accommodate the changes in CHM calculation, including verification for voxel processing and grid orientation. Additionally, revised test cases to handle larger datasets and improved CHM height checks.